### PR TITLE
Refactor/doc builder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.icij.datashare</groupId>
     <artifactId>datashare-api</artifactId>
-    <version>9.2.0-SNAPSHOT</version>
+    <version>10.0.0</version>
     <packaging>jar</packaging>
 
     <name>ICIJ Datashare API</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.icij.datashare</groupId>
     <artifactId>datashare-api</artifactId>
-    <version>9.0.2</version>
+    <version>9.1.0</version>
     <packaging>jar</packaging>
 
     <name>ICIJ Datashare API</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.icij.datashare</groupId>
     <artifactId>datashare-api</artifactId>
-    <version>9.1.0</version>
+    <version>9.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ICIJ Datashare API</name>

--- a/src/main/java/org/icij/datashare/json/JsonObjectMapper.java
+++ b/src/main/java/org/icij/datashare/json/JsonObjectMapper.java
@@ -1,9 +1,7 @@
 package org.icij.datashare.json;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.type.CollectionType;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import org.icij.datashare.Entity;
@@ -15,7 +13,6 @@ import org.icij.datashare.text.indexing.IndexType;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
@@ -38,18 +35,6 @@ public class JsonObjectMapper {
 
     // JSON - Object mapper
     public static final ObjectMapper MAPPER = new ObjectMapper();
-
-    private static final  TypeReference<HashMap<String,Object>> TYPE_REF_MAP_STRING_OBJECT = new TypeReference<>(){};
-    public static HashMap<String,Object> getHashMapStringObject(final String mapStr) throws JsonProcessingException {
-        CollectionType collectionType = MAPPER.getTypeFactory().constructCollectionType(List.class, TYPE_REF_MAP_STRING_OBJECT.getClass());
-        return MAPPER.readValue(mapStr, collectionType);
-    }
-    private static final   TypeReference<List<Long>> TYPE_REF_LIST_LONG = new TypeReference<>() {};
-    public static List<Long> getLongList(final String listStr) throws JsonProcessingException {
-        CollectionType collectionType = MAPPER.getTypeFactory().constructCollectionType(List.class, TYPE_REF_LIST_LONG.getClass());
-        return MAPPER.readValue(listStr, collectionType);
-    }
-
     static {
         // Handle Optional and other JDK 8 only features
         MAPPER.registerModule(new Jdk8Module());

--- a/src/main/java/org/icij/datashare/json/JsonObjectMapper.java
+++ b/src/main/java/org/icij/datashare/json/JsonObjectMapper.java
@@ -1,7 +1,9 @@
 package org.icij.datashare.json;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.CollectionType;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import org.icij.datashare.Entity;
@@ -13,6 +15,7 @@ import org.icij.datashare.text.indexing.IndexType;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
@@ -35,6 +38,18 @@ public class JsonObjectMapper {
 
     // JSON - Object mapper
     public static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final  TypeReference<HashMap<String,Object>> TYPE_REF_MAP_STRING_OBJECT = new TypeReference<>(){};
+    public static HashMap<String,Object> getHashMapStringObject(final String mapStr) throws JsonProcessingException {
+        CollectionType collectionType = MAPPER.getTypeFactory().constructCollectionType(List.class, TYPE_REF_MAP_STRING_OBJECT.getClass());
+        return MAPPER.readValue(mapStr, collectionType);
+    }
+    private static final   TypeReference<List<Long>> TYPE_REF_LIST_LONG = new TypeReference<>() {};
+    public static List<Long> getLongList(final String listStr) throws JsonProcessingException {
+        CollectionType collectionType = MAPPER.getTypeFactory().constructCollectionType(List.class, TYPE_REF_LIST_LONG.getClass());
+        return MAPPER.readValue(listStr, collectionType);
+    }
+
     static {
         // Handle Optional and other JDK 8 only features
         MAPPER.registerModule(new Jdk8Module());

--- a/src/main/java/org/icij/datashare/text/Document.java
+++ b/src/main/java/org/icij/datashare/text/Document.java
@@ -77,11 +77,11 @@ public class Document implements Entity {
     private final String rootDocument;
 
 
-    public Document(Project project, String id, Path filePath, String content, Language language, Charset charset, String mimetype, Map<String, Object> metadata, Status status, Set<Pipeline.Type> nerTags, Date extractionDate, String parentDocument, String rootDocument, Short extractionLevel, Long contentLength) {
+    Document(Project project, String id, Path filePath, String content, Language language, Charset charset, String mimetype, Map<String, Object> metadata, Status status, Set<Pipeline.Type> nerTags, Date extractionDate, String parentDocument, String rootDocument, Short extractionLevel, Long contentLength) {
         this(project, id, filePath, content,null, language, extractionDate, charset, mimetype, extractionLevel, metadata, status, nerTags, parentDocument, rootDocument, contentLength, new HashSet<>());
     }
 
-    public Document(Project project, String id, Path filePath, String content, List<Map<String,String>> content_translated, Language language, Charset charset,
+    Document(Project project, String id, Path filePath, String content, List<Map<String,String>> content_translated, Language language, Charset charset,
                     String mimetype, Map<String, Object> metadata, Status status, Set<Pipeline.Type> nerTags,
                     Date extractionDate, String parentDocument, String rootDocument, Short extractionLevel,
                     Long contentLength, Set<Tag> tags) {
@@ -125,7 +125,7 @@ public class Document implements Entity {
         this.tags = tags;
     }
 
-    private static String getHash(Project project, Path path) {
+    static String getHash(Project project, Path path) {
         return HASHER.hash(path, project.getId());
     }
 

--- a/src/main/java/org/icij/datashare/text/Document.java
+++ b/src/main/java/org/icij/datashare/text/Document.java
@@ -76,27 +76,9 @@ public class Document implements Entity {
     @IndexRoot
     private final String rootDocument;
 
-    public Document(Project project, Path filePath, String content, Language language, Charset charset, String mimetype, Map<String, Object> metadata, Status status, Long contentLength) {
-        this(project, getHash(project, filePath), filePath, content,null, language, new Date(), charset, mimetype, 0, metadata, status, new HashSet<>(), null, null, contentLength, new HashSet<>());
-    }
 
     public Document(Project project, String id, Path filePath, String content, Language language, Charset charset, String mimetype, Map<String, Object> metadata, Status status, Set<Pipeline.Type> nerTags, Date extractionDate, String parentDocument, String rootDocument, Short extractionLevel, Long contentLength) {
         this(project, id, filePath, content,null, language, extractionDate, charset, mimetype, extractionLevel, metadata, status, nerTags, parentDocument, rootDocument, contentLength, new HashSet<>());
-    }
-
-    public Document(Project project, Path filePath, String content, Language language, Charset charset, String mimetype, Map<String, Object> metadata, Status status, Set<Pipeline.Type> nerTags, Long contentLength) {
-        this(project, getHash(project, filePath), filePath, content,null, language, new Date(), charset, mimetype, 0, metadata, status, nerTags, null, null, contentLength, new HashSet<>());
-    }
-
-    public Document(String id, Project project, Path filePath, String content, Language language, Charset charset, String mimetype, Map<String, Object> metadata, Status status, Set<Pipeline.Type> nerTags, Long contentLength) {
-        this(project, id, filePath, content, null, language, new Date(), charset, mimetype, 0, metadata, status, nerTags, null, null, contentLength, new HashSet<>());
-    }
-
-    public Document(Project project, Path filePath, String content, Language language, Charset charset, String mimetype, Map<String, Object> metadata, Status status, HashSet<Pipeline.Type> nerTags, Document parentDocument, Long contentLength) {
-        this(project, getHash(project, filePath), filePath, content, null, language, new Date(), charset, mimetype, 0, metadata, status, nerTags, parentDocument.getId(), parentDocument.getRootDocument(), contentLength, new HashSet<>());
-    }
-    public Document(String id, Project project, Path filePath, String content, List<Map<String,String>> content_translated, Language language, Charset charset, String mimetype, Map<String, Object> metadata, Status status, Set<Pipeline.Type> nerTags, Long contentLength) {
-        this(project, id, filePath, content, content_translated, language, new Date(), charset, mimetype, 0, metadata, status, nerTags, null, null, contentLength, new HashSet<>());
     }
 
     public Document(Project project, String id, Path filePath, String content, List<Map<String,String>> content_translated, Language language, Charset charset,
@@ -104,15 +86,6 @@ public class Document implements Entity {
                     Date extractionDate, String parentDocument, String rootDocument, Short extractionLevel,
                     Long contentLength, Set<Tag> tags) {
         this(project, id, filePath, content, content_translated, language, extractionDate, charset,
-                mimetype, extractionLevel, metadata, status, nerTags,
-                parentDocument, rootDocument, contentLength,
-                tags);
-    }
-    public Document(Project project, Path filePath, String content, List<Map<String,String>> content_translated, Language language, Charset charset,
-                    String mimetype, Map<String, Object> metadata, Status status, Set<Pipeline.Type> nerTags,
-                    Date extractionDate, String parentDocument, String rootDocument, Short extractionLevel,
-                    Long contentLength, Set<Tag> tags) {
-        this(project, getHash(project, filePath), filePath, content, content_translated, language, extractionDate, charset,
                 mimetype, extractionLevel, metadata, status, nerTags,
                 parentDocument, rootDocument, contentLength,
                 tags);

--- a/src/main/java/org/icij/datashare/text/Document.java
+++ b/src/main/java/org/icij/datashare/text/Document.java
@@ -24,6 +24,7 @@ import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toSet;
 
 
+
 @IndexType("Document")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Document implements Entity {
@@ -94,14 +95,33 @@ public class Document implements Entity {
     public Document(Project project, Path filePath, String content, Language language, Charset charset, String mimetype, Map<String, Object> metadata, Status status, HashSet<Pipeline.Type> nerTags, Document parentDocument, Long contentLength) {
         this(project, getHash(project, filePath), filePath, content, null, language, new Date(), charset, mimetype, 0, metadata, status, nerTags, parentDocument.getId(), parentDocument.getRootDocument(), contentLength, new HashSet<>());
     }
-    public Document(String id, Project project, Path filePath, String content,List<Map<String,String>> content_translated, Language language, Charset charset, String mimetype, Map<String, Object> metadata, Status status, Set<Pipeline.Type> nerTags, Long contentLength) {
+    public Document(String id, Project project, Path filePath, String content, List<Map<String,String>> content_translated, Language language, Charset charset, String mimetype, Map<String, Object> metadata, Status status, Set<Pipeline.Type> nerTags, Long contentLength) {
         this(project, id, filePath, content, content_translated, language, new Date(), charset, mimetype, 0, metadata, status, nerTags, null, null, contentLength, new HashSet<>());
+    }
+
+    public Document(Project project, String id, Path filePath, String content, List<Map<String,String>> content_translated, Language language, Charset charset,
+                    String mimetype, Map<String, Object> metadata, Status status, Set<Pipeline.Type> nerTags,
+                    Date extractionDate, String parentDocument, String rootDocument, Short extractionLevel,
+                    Long contentLength, Set<Tag> tags) {
+        this(project, id, filePath, content, content_translated, language, extractionDate, charset,
+                mimetype, extractionLevel, metadata, status, nerTags,
+                parentDocument, rootDocument, contentLength,
+                tags);
+    }
+    public Document(Project project, Path filePath, String content, List<Map<String,String>> content_translated, Language language, Charset charset,
+                    String mimetype, Map<String, Object> metadata, Status status, Set<Pipeline.Type> nerTags,
+                    Date extractionDate, String parentDocument, String rootDocument, Short extractionLevel,
+                    Long contentLength, Set<Tag> tags) {
+        this(project, getHash(project, filePath), filePath, content, content_translated, language, extractionDate, charset,
+                mimetype, extractionLevel, metadata, status, nerTags,
+                parentDocument, rootDocument, contentLength,
+                tags);
     }
 
     @JsonCreator
     private Document(@JsonProperty("projectId") Project project, @JsonProperty("id") String id, @JsonProperty("path") Path path,
                      @JsonProperty("content") String content,
-                     @JsonProperty("content_translated") List<Map<String,String>> contentTranslated,
+                     @JsonProperty("content_translated") List<Map<String,String>> content_translated,
                      @JsonProperty("language") Language language, @JsonProperty("extractionDate") Date extractionDate,
                      @JsonProperty("contentEncoding") Charset contentEncoding, @JsonProperty("contentType") String contentType,
                      @JsonProperty("extractionLevel") int extractionLevel,
@@ -117,7 +137,7 @@ public class Document implements Entity {
         this.path = path;
         this.dirname = path == null ? null: getDirnameFrom(path);
         this.content = ofNullable(content).orElse("");
-        this.content_translated = ofNullable(contentTranslated).orElse(new ArrayList<>());
+        this.content_translated = ofNullable(content_translated).orElse(new ArrayList<>());
         this.extractionDate = extractionDate;
         this.extractionLevel = (short)extractionLevel;
         this.contentLength = ofNullable(contentLength).orElse(0L);
@@ -142,6 +162,8 @@ public class Document implements Entity {
     public Project getProject() { return project;}
     public String getProjectId() { return project.getId();}
     public String getContent() { return content; }
+    @JsonGetter("content_translated")
+    public List<Map<String, String>> getContentTranslated() { return content_translated; }
     public int getContentTextLength() { return content.length();}
     public Path getPath() { return path;}
     public Path getDirname() { return dirname;}

--- a/src/main/java/org/icij/datashare/text/DocumentBuilder.java
+++ b/src/main/java/org/icij/datashare/text/DocumentBuilder.java
@@ -57,6 +57,10 @@ public class DocumentBuilder {
         return this;
     }
 
+    public DocumentBuilder withId(String id) {
+        this.id = id;
+        return this;
+    }
     public DocumentBuilder with(String content) {
         this.content = content;
         return this;
@@ -97,7 +101,7 @@ public class DocumentBuilder {
         return this;
     }
 
-    public DocumentBuilder with(Pipeline.Type ... pipelineTypes) {
+    public DocumentBuilder with(Pipeline.Type... pipelineTypes) {
         this.pipelines = Arrays.stream(pipelineTypes).collect(toSet());
         return this;
     }
@@ -109,7 +113,7 @@ public class DocumentBuilder {
         this.project = project;
         return this;
     }
-    public DocumentBuilder with(Tag ... tags) {
+    public DocumentBuilder with(Tag... tags) {
         this.tags = Arrays.stream(tags).collect(toSet());
         return this;
     }

--- a/src/main/java/org/icij/datashare/text/DocumentBuilder.java
+++ b/src/main/java/org/icij/datashare/text/DocumentBuilder.java
@@ -1,37 +1,63 @@
 package org.icij.datashare.text;
 
+import org.icij.datashare.Entity;
 import org.icij.datashare.text.nlp.Pipeline;
 
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.*;
-
 import static java.nio.file.Paths.get;
 import static java.util.stream.Collectors.toSet;
 import static org.icij.datashare.text.Language.ENGLISH;
 import static org.icij.datashare.text.Project.project;
 
-public class DocumentBuilder {
-    private String id;
+public class DocumentBuilder  implements Entity {
+    private final String id;
     private String content;
+    private List<Map<String, String>> content_translated;
     private Path path;
     private Map<String, Object> metadata = new HashMap<>();
     private String mimeType;
     private Set<Pipeline.Type> pipelines;
+    private String parentId = null;
     private String rootId = null;
+    private Set<Tag> tags;
+    private Project project;
     private Language language = ENGLISH;
+    private short extractionLevel;
+    private Charset charset;
+    private Document.Status documentStatus;
+    private Date extractionDate;
+    private Long contentLength;
 
     public static DocumentBuilder createDoc(String id) {
+
         return new DocumentBuilder(id);
+    }
+    public static DocumentBuilder createDoc(Project project,Path path) {
+        return new DocumentBuilder(getHash(project,path)).with(project).with(path);
+    }
+    private static String getHash(Project project, Path path) {
+        try {
+            return HASHER.hash(path, project.getId());
+        } catch(IllegalArgumentException e){
+            return HASHER.hash(project.getId()+path);
+        }
     }
 
     private DocumentBuilder(String id) {
         this.id = id;
+        this.charset = Charset.defaultCharset();
         this.content = id;
+        this.contentLength = (long) content.getBytes(this.charset).length;
+        this.documentStatus = Document.Status.INDEXED;
+        this.extractionDate = new Date();
+        this.extractionLevel = 0;
         this.path = get("/path/to/").resolve(id);
         this.mimeType = "text/plain";
         this.pipelines = new HashSet<>();
+        this.project = project("prj");
+        this.tags = new HashSet<>();
     }
 
     public DocumentBuilder with(String content) {
@@ -54,14 +80,23 @@ public class DocumentBuilder {
         return this;
     }
 
-    public Document build() {
-        return new Document(project("prj"), id, path, content, language, Charset.defaultCharset(),
-                         mimeType, metadata, Document.Status.INDEXED,
-                        pipelines, new Date(), rootId, rootId, (short) 0, (long) content.getBytes(StandardCharsets.UTF_8).length);
+    public DocumentBuilder with(List<Map<String, String>> contentTranslated) {
+        this.content_translated = contentTranslated;
+        return this;
     }
 
     public DocumentBuilder ofMimeType(String mimeType) {
-        this.mimeType=mimeType;
+        this.mimeType = mimeType;
+        return this;
+    }
+
+    public DocumentBuilder with(Charset charset) {
+        this.charset = charset;
+        return this;
+    }
+
+    public DocumentBuilder extractedAt(Date extractionDate) {
+        this.extractionDate = extractionDate;
         return this;
     }
 
@@ -69,9 +104,47 @@ public class DocumentBuilder {
         this.pipelines = Arrays.stream(pipelineTypes).collect(toSet());
         return this;
     }
+    public DocumentBuilder with(Document.Status documentStatus) {
+        this.documentStatus = documentStatus;
+        return this;
+    }
+    public DocumentBuilder with(Project project) {
+        this.project = project;
+        return this;
+    }
+    public DocumentBuilder with(Tag ... tags) {
+        this.tags = Arrays.stream(tags).collect(toSet());
+        return this;
+    }
+    public DocumentBuilder withExtractionLevel(short extractionLevel) {
+        this.extractionLevel = extractionLevel;
+        return this;
+    }
+    public DocumentBuilder withContentLength(long contentLength) {
+        this.contentLength = contentLength;
+        return this;
+    }
 
     public DocumentBuilder withRootId(String rootId) {
-        this.rootId=rootId;
+        this.rootId = rootId;
         return this;
+    }
+    public DocumentBuilder withParentId(String parentId) {
+        this.parentId = parentId;
+        return this;
+    }
+    public Document build() {
+        if(id == null && path == null){
+            System.out.println("Path and id are missing.");
+        }
+        return new Document(project, id, path, content, content_translated, language,
+                charset, mimeType, metadata, documentStatus,
+                pipelines, extractionDate, rootId, parentId, extractionLevel,
+                contentLength, tags);
+    }
+
+    @Override
+    public String getId() {
+        return id;
     }
 }

--- a/src/main/java/org/icij/datashare/text/DocumentBuilder.java
+++ b/src/main/java/org/icij/datashare/text/DocumentBuilder.java
@@ -1,18 +1,18 @@
 package org.icij.datashare.text;
 
-import org.icij.datashare.Entity;
 import org.icij.datashare.text.nlp.Pipeline;
 
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.*;
+
 import static java.nio.file.Paths.get;
 import static java.util.stream.Collectors.toSet;
 import static org.icij.datashare.text.Language.ENGLISH;
 import static org.icij.datashare.text.Project.project;
 
-public class DocumentBuilder  implements Entity {
-    private final String id;
+public class DocumentBuilder {
+    private String id;
     private String content;
     private List<Map<String, String>> content_translated;
     private Path path;
@@ -30,22 +30,18 @@ public class DocumentBuilder  implements Entity {
     private Date extractionDate;
     private Long contentLength;
 
+    private DocumentBuilder() {}
+    public static DocumentBuilder createDoc() {
+        return new DocumentBuilder();
+    }
     public static DocumentBuilder createDoc(String id) {
-
-        return new DocumentBuilder(id);
+        return new DocumentBuilder().withDefaultValues(id);
     }
-    public static DocumentBuilder createDoc(Project project,Path path) {
-        return new DocumentBuilder(getHash(project,path)).with(project).with(path);
-    }
-    private static String getHash(Project project, Path path) {
-        try {
-            return HASHER.hash(path, project.getId());
-        } catch(IllegalArgumentException e){
-            return HASHER.hash(project.getId()+path);
-        }
+    public static DocumentBuilder createDoc(Project project, Path path) {
+        return new DocumentBuilder().withDefaultValues(Document.getHash(project,path)).with(project).with(path);
     }
 
-    private DocumentBuilder(String id) {
+    public DocumentBuilder withDefaultValues(String id){
         this.id = id;
         this.charset = Charset.defaultCharset();
         this.content = id;
@@ -58,6 +54,7 @@ public class DocumentBuilder  implements Entity {
         this.pipelines = new HashSet<>();
         this.project = project("prj");
         this.tags = new HashSet<>();
+        return this;
     }
 
     public DocumentBuilder with(String content) {
@@ -134,8 +131,8 @@ public class DocumentBuilder  implements Entity {
         return this;
     }
     public Document build() {
-        if(id == null && path == null){
-            System.out.println("Path and id are missing.");
+        if(id == null && project == null && path == null && content == null){
+            throw new NullPointerException("Id, Project, Path or content are missing.");
         }
         return new Document(project, id, path, content, content_translated, language,
                 charset, mimeType, metadata, documentStatus,
@@ -143,8 +140,4 @@ public class DocumentBuilder  implements Entity {
                 contentLength, tags);
     }
 
-    @Override
-    public String getId() {
-        return id;
-    }
 }

--- a/src/test/java/org/icij/datashare/text/DocumentTest.java
+++ b/src/test/java/org/icij/datashare/text/DocumentTest.java
@@ -3,9 +3,7 @@ package org.icij.datashare.text;
 import org.icij.datashare.json.JsonObjectMapper;
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
+import java.util.*;
 
 import static java.nio.file.Paths.get;
 import static org.fest.assertions.Assertions.assertThat;
@@ -92,5 +90,21 @@ public class DocumentTest {
     public void test_creation_date_unparseable() {
         assertThat(createDoc("name").with(new HashMap<String, Object>() {{
             put("tika_metadata_dcterms_created", "not a date");}}).build().getCreationDate()).isNull();
+    }
+
+    @Test
+    public void test_content_translated() throws Exception {
+        Map<String, String> english = new HashMap<>();
+        english.put("content","hello world");
+        english.put("target_language","ENGLISH");
+        List<Map<String,String>> content_translated = new ArrayList<>(){{add(english); }};
+        Document doc = createDoc("name").with(content_translated).build();
+        assertThat(doc.getContentTranslated()).isNotNull();
+        assertThat(JsonObjectMapper.MAPPER.writeValueAsString(doc)).contains("\"content_translated\":[{\"target_language\":\"ENGLISH\",\"content\":\"hello world\"}]");
+    }
+
+    @Test
+    public void test_serialize_contains_content_translated() throws Exception {
+        assertThat(JsonObjectMapper.MAPPER.writeValueAsString(createDoc("content").build())).contains("\"content_translated\":[]");
     }
 }


### PR DESCRIPTION
BREAKING changes: 
We removed public Document constructors to force the use of the document builder

- Add [content translated to document](https://github.com/ICIJ/datashare-api/pull/11/commits/b7c2d1c65d9b70055d9697b6829045aafe7f64da)
- Update document builder api with all document attributes.
- Add default values for document builder for tests
- Remove unused document constructor
