### PR TITLE
feat: add Project properties and adapt other tests

### DIFF
--- a/src/main/java/org/icij/datashare/text/Project.java
+++ b/src/main/java/org/icij/datashare/text/Project.java
@@ -8,6 +8,7 @@ import org.icij.datashare.Entity;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Date;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
@@ -24,28 +25,68 @@ public class Project implements Entity {
     public final String allowFromMask;
     @JsonIgnore
     private final Pattern pattern;
+    public final String label;
+    public final String publisherName;
+    public final String maintainerName;
+    public final String logoUrl;
+    public final String sourceUrl;
+    public final Date creationDate;
+    public final Date updateDate;
+
 
     @JsonCreator(mode = DELEGATING)
-    public Project(String corpusName) {
-        this(corpusName, Paths.get("/vault").resolve(corpusName), "*");
+    public Project(String name) {
+        this(name, Paths.get("/vault").resolve(name), "*");
     }
     @JsonCreator(mode = PROPERTIES)
-    public Project( @JsonProperty("name") String corpusName,
+    public Project( @JsonProperty("name") String name,
                     @JsonProperty("sourcePath") Path sourcePath) {
-        this(corpusName, sourcePath, "*");
+        this(name, sourcePath, "*");
     }
 
-    public Project(String corpusName, Path source, String allowFromMask) {
-        name = corpusName;
-        sourcePath = source;
+    public Project(String name, Path sourcePath, String allowFromMask) {
+        this.name = name;
+        this.label = name;
+        this.sourcePath = sourcePath;
+        this.sourceUrl = null;
+        this.maintainerName = null;
+        this.publisherName = null;
+        this.logoUrl = null;
+        this.creationDate = new Date();
+        this.updateDate = new Date();
         this.allowFromMask = allowFromMask;
         this.pattern = Pattern.compile(allowFromMask.
                 replace(".", "\\.").
                 replace("*", "\\d{1,3}"));
     }
 
-    public Project(String corpusName, String allowFromMask) {
-        this(corpusName, Paths.get("/vault").resolve(corpusName), allowFromMask);
+    public Project(String name,
+                   String label,
+                   Path sourcePath,
+                   String sourceUrl,
+                   String maintainerName,
+                   String publisherName,
+                   String logoUrl,
+                   String allowFromMask,
+                   Date creationDate,
+                   Date updateDate) {
+        this.name = name;
+        this.label = label;
+        this.sourcePath = sourcePath;
+        this.sourceUrl = sourceUrl;
+        this.maintainerName = maintainerName;
+        this.publisherName = publisherName;
+        this.logoUrl = logoUrl;
+        this.allowFromMask = allowFromMask;
+        this.creationDate = creationDate;
+        this.updateDate = updateDate;
+        this.pattern = Pattern.compile(allowFromMask.
+                replace(".", "\\.").
+                replace("*", "\\d{1,3}"));
+    }
+
+    public Project(String name, String allowFromMask) {
+        this(name, Paths.get("/vault").resolve(name), allowFromMask);
     }
 
     public boolean isAllowed(final InetSocketAddress socketAddress) {
@@ -61,12 +102,39 @@ public class Project implements Entity {
     public String getId() {
         return name;
     }
+
     public String getName() {
         return name;
     }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String getMaintainerName() {
+        return maintainerName;
+    }
+
+    public String getAllowFromMask() {
+        return allowFromMask;
+    }
+
+    public String getLogoUrl() {
+        return logoUrl;
+    }
+
+    public String getSourceUrl() {
+        return sourceUrl;
+    }
+
     public Path getSourcePath() {
         return sourcePath;
     }
+
+    public String getPublisherName() {
+        return publisherName;
+    }
+
     public static Project project(final String projectName) {
         return new Project(projectName);
     }

--- a/src/main/java/org/icij/datashare/user/User.java
+++ b/src/main/java/org/icij/datashare/user/User.java
@@ -80,6 +80,7 @@ public class User implements Entity {
         return (List<String>) ofNullable(applications.get(XEMX_DATASHARE_KEY)).orElse(new LinkedList<>());
     }
 
+
     @JsonIgnore
     public Map<String, Object> getDetails() {
         return details.entrySet().stream().

--- a/src/test/java/org/icij/datashare/NoteTest.java
+++ b/src/test/java/org/icij/datashare/NoteTest.java
@@ -14,7 +14,13 @@ import static org.fest.assertions.Assertions.assertThat;
 public class NoteTest {
     @Test
     public void serialize_note() throws JsonProcessingException {
-        assertThat(JsonObjectMapper.MAPPER.writeValueAsString(new Note(Project.project("projet"), Paths.get("toto/tata"),"This is a test"))).isEqualTo("{\"project\":{\"name\":\"projet\",\"sourcePath\":\"file:///vault/projet\"},\"path\":\"toto/tata\",\"note\":\"This is a test\",\"variant\":\"info\"}");
+        Note note = new Note(Project.project("projet"), Paths.get("toto/tata"),"This is a test");
+        assertThat(JsonObjectMapper.MAPPER.writeValueAsString(note))
+                .contains("\"name\":\"projet\"")
+                .contains("\"label\":\"projet\"")
+                .contains("\"sourcePath\":\"file:///vault/projet\"")
+                .contains("\"note\":\"This is a test\"")
+                .contains("\"variant\":\"info\"");
     }
 
     @Test

--- a/src/test/java/org/icij/datashare/batch/SearchResultTest.java
+++ b/src/test/java/org/icij/datashare/batch/SearchResultTest.java
@@ -13,8 +13,12 @@ import static org.fest.assertions.Assertions.assertThat;
 public class SearchResultTest {
     @Test
     public void test_json_serialize() throws Exception {
-        assertThat(JsonObjectMapper.MAPPER.writeValueAsString(new SearchResult("q1", Project.project("prj"),"docId1", "rootId1", Paths.get("/path/to/doc1"),
-                new Date(), "content/type", 123L, 1))).contains("\"project\":{\"name\":\"prj\",\"sourcePath\":\"file:///vault/prj\"}").contains("\"documentPath\":\"/path/to/doc1\"");
+        Project project = Project.project("prj");
+        SearchResult searchResult = new SearchResult("q1", project, "docId1", "rootId1", Paths.get("/path/to/doc1"), new Date(), "content/type", 123L, 1);
+        assertThat(JsonObjectMapper.MAPPER.writeValueAsString(searchResult))
+            .contains("\"name\":\"prj\"")
+            .contains("\"sourcePath\":\"file:///vault/prj\"")
+            .contains("\"documentPath\":\"/path/to/doc1\"");
         SearchResult searchResultFromJson = JsonObjectMapper.MAPPER.readValue(("{\"query\":\"q1\"," +
                         "\"project\":{\"name\":\"prj\",\"sourcePath\":\"file:///vault/prj\"}," +
                         "\"documentId\":\"docId1\"," +

--- a/src/test/java/org/icij/datashare/text/ProjectTest.java
+++ b/src/test/java/org/icij/datashare/text/ProjectTest.java
@@ -1,0 +1,21 @@
+package org.icij.datashare.text;
+
+import org.icij.datashare.text.Project;
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+
+public class ProjectTest {
+
+    @Test()
+    public void test_constructor_with_only_name_and_default_values() {
+        Project project = new Project("local-datashare");
+        assertThat(project.name).isEqualTo("local-datashare");
+        assertThat(project.label).isEqualTo("local-datashare");
+        assertThat(project.allowFromMask).isEqualTo("*");
+    }
+}


### PR DESCRIPTION
This PR add the following properties to the Project class:

* label
* sourceUrl
* maintainerName
* publisherName
* logoUrl
* creationDate
* updateDate

As intended, those properties are not ignored by the JSON serializer. Other tests where instantiating Project and comparing the generated JSON. I adapted those test to only check pieces of the JSON instead of an entire serialized object.