### PR TITLE
feat: add projects accessors

### DIFF
--- a/src/main/java/org/icij/datashare/user/User.java
+++ b/src/main/java/org/icij/datashare/user/User.java
@@ -23,7 +23,7 @@ public class User implements Entity {
     public final String email;
     public final String provider;
     public final Map<String, Object> details;
-    private List<String> projects = new ArrayList<>();
+    private final List<String> projects = new ArrayList<>();
 
     public User(final String id, String name, String email, String provider, String jsonDetails) {
         this.id = id;

--- a/src/main/java/org/icij/datashare/user/User.java
+++ b/src/main/java/org/icij/datashare/user/User.java
@@ -23,6 +23,7 @@ public class User implements Entity {
     public final String email;
     public final String provider;
     public final Map<String, Object> details;
+    private List<String> projects = new ArrayList<>();
 
     public User(final String id, String name, String email, String provider, String jsonDetails) {
         this.id = id;
@@ -75,11 +76,40 @@ public class User implements Entity {
     }
 
     @JsonIgnore
-    public List<String> getProjects() {
+    public List<String> getApplicationProjects() {
         HashMap<String, Object> applications = (HashMap<String, Object>) ofNullable(details.get(XEMX_APPLICATIONS_KEY)).orElse(new HashMap<>());
         return (List<String>) ofNullable(applications.get(XEMX_DATASHARE_KEY)).orElse(new LinkedList<>());
     }
 
+    @JsonIgnore
+    public List<String> getProjects() {
+        HashSet<String> uniqueProjects = new HashSet<>();
+
+        uniqueProjects.addAll(projects);
+        uniqueProjects.addAll(getApplicationProjects());
+
+        return new ArrayList<>(uniqueProjects);
+    }
+
+    @JsonIgnore
+    public void addProject(String newProject) {
+        if (!getProjects().contains(newProject)) {
+            projects.add(newProject);
+        }
+    }
+
+    @JsonIgnore
+    public void addProjects(List<String> newProjects) {
+        // We add each project one by one to ensure that even if `newProjects` contains
+        // duplicates, they are only added once
+        newProjects.forEach(this::addProject);
+    }
+
+    @JsonIgnore
+    public void setProjects(List<String> newProjects) {
+        projects.clear();
+        addProjects(newProjects);
+    }
 
     @JsonIgnore
     public Map<String, Object> getDetails() {

--- a/src/test/java/org/icij/datashare/user/UserTest.java
+++ b/src/test/java/org/icij/datashare/user/UserTest.java
@@ -6,6 +6,7 @@ import org.icij.datashare.batch.BatchDownload;
 import org.icij.datashare.time.DatashareTime;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -111,5 +112,40 @@ public class UserTest {
         assertThat(copy.email).isEqualTo("email");
         assertThat(copy.provider).isEqualTo("provider");
         assertThat(copy.details).isEqualTo(new HashMap<>());
+    }
+
+    @Test
+    public void test_can_set_one_project() {
+        User user = new User("id", "name", "email", "provider", "{}");
+        user.setProjects(Collections.singletonList("foo"));
+        assertThat(user.getProjects()).hasSize(1);
+        assertThat(user.getProjects()).contains("foo");
+    }
+
+    @Test
+    public void test_can_set_several_projects() {
+        User user = new User("id", "name", "email", "provider", "{}");
+        user.setProjects(Arrays.asList("foo", "bar"));
+        assertThat(user.getProjects()).hasSize(2);
+        assertThat(user.getProjects()).contains("foo");
+        assertThat(user.getProjects()).contains("bar");
+    }
+
+    @Test
+    public void test_can_set_several_duplicated_projects() {
+        User user = new User("id", "name", "email", "provider", "{}");
+        user.setProjects(Arrays.asList("foo", "bar", "foo"));
+        assertThat(user.getProjects()).hasSize(2);
+        assertThat(user.getProjects()).contains("foo");
+        assertThat(user.getProjects()).contains("bar");
+    }
+
+    @Test
+    public void test_can_set_several_projects_in_addition_to_json_detail() {
+        User user = new User("id", "name", "email", "provider", "{ \"groups_by_applications\": { \"datashare\": [\"foo\"] } }");
+        user.setProjects(Collections.singletonList("bar"));
+        assertThat(user.getProjects()).hasSize(2);
+        assertThat(user.getProjects()).contains("foo");
+        assertThat(user.getProjects()).contains("bar");
     }
 }

--- a/src/test/java/org/icij/datashare/user/UserTest.java
+++ b/src/test/java/org/icij/datashare/user/UserTest.java
@@ -57,8 +57,8 @@ public class UserTest {
 
     @Test
     public void test_get_indices_for_local_user() {
-        assertThat(User.local().getProjects()).containsExactly("local-datashare");
-        assertThat(User.localUser("foo").getProjects()).containsExactly("foo-datashare");
+        assertThat(User.local().getProjectNames()).containsExactly("local-datashare");
+        assertThat(User.localUser("foo").getProjectNames()).containsExactly("foo-datashare");
     }
 
     @Test
@@ -68,7 +68,7 @@ public class UserTest {
             put("groups_by_applications", new HashMap<String, Object>() {{
                 put("datashare", Collections.singletonList("external_index"));
             }});
-        }}).getProjects()).containsExactly("external_index");
+        }}).getProjectNames()).containsExactly("external_index");
     }
 
     @Test
@@ -118,34 +118,53 @@ public class UserTest {
     public void test_can_set_one_project() {
         User user = new User("id", "name", "email", "provider", "{}");
         user.setProjects(Collections.singletonList("foo"));
-        assertThat(user.getProjects()).hasSize(1);
-        assertThat(user.getProjects()).contains("foo");
+        assertThat(user.getProjectNames()).hasSize(1);
+        assertThat(user.getProjectNames()).contains("foo");
     }
 
     @Test
     public void test_can_set_several_projects() {
         User user = new User("id", "name", "email", "provider", "{}");
         user.setProjects(Arrays.asList("foo", "bar"));
-        assertThat(user.getProjects()).hasSize(2);
-        assertThat(user.getProjects()).contains("foo");
-        assertThat(user.getProjects()).contains("bar");
+        assertThat(user.getProjectNames()).hasSize(2);
+        assertThat(user.getProjectNames()).contains("foo");
+        assertThat(user.getProjectNames()).contains("bar");
     }
 
     @Test
     public void test_can_set_several_duplicated_projects() {
         User user = new User("id", "name", "email", "provider", "{}");
         user.setProjects(Arrays.asList("foo", "bar", "foo"));
-        assertThat(user.getProjects()).hasSize(2);
-        assertThat(user.getProjects()).contains("foo");
-        assertThat(user.getProjects()).contains("bar");
+        assertThat(user.getProjectNames()).hasSize(2);
+        assertThat(user.getProjectNames()).contains("foo");
+        assertThat(user.getProjectNames()).contains("bar");
     }
 
     @Test
     public void test_can_set_several_projects_in_addition_to_json_detail() {
         User user = new User("id", "name", "email", "provider", "{ \"groups_by_applications\": { \"datashare\": [\"foo\"] } }");
         user.setProjects(Collections.singletonList("bar"));
-        assertThat(user.getProjects()).hasSize(2);
-        assertThat(user.getProjects()).contains("foo");
-        assertThat(user.getProjects()).contains("bar");
+        assertThat(user.getProjectNames()).hasSize(2);
+        assertThat(user.getProjectNames()).contains("foo");
+        assertThat(user.getProjectNames()).contains("bar");
+    }
+
+    @Test
+    public void test_clear_projects_but_details() {
+        User user = new User("id", "name", "email", "provider", "{ \"groups_by_applications\": { \"datashare\": [\"foo\"] } }");
+        user.setProjects(Collections.singletonList("bar"));
+        assertThat(user.getProjectNames()).hasSize(2);
+        user.clearProjects();
+        assertThat(user.getProjectNames()).hasSize(1);
+        assertThat(user.getProjectNames()).contains("foo");
+    }
+
+    @Test
+    public void test_clear_projects() {
+        User user = new User("id", "name", "email", "provider");
+        user.setProjects(Collections.singletonList("bar"));
+        assertThat(user.getProjectNames()).hasSize(1);
+        user.clearProjects();
+        assertThat(user.getProjectNames()).hasSize(0);
     }
 }


### PR DESCRIPTION
## PR description

This PR add a `projects` property to the User class which can be used to add additional projects (not depending on the `details`). 

## Breaking Changes

* The `getProjects` method now returns a `List<Project>`.
 
## Changes

* Rename `getProjects` method to `getApplicationProjects`
* Create a `projects` property to the User class
* Create a new `getProjects` method to combine `getApplicationProjects` with the `projects` property
* Create a `addProject` method to add a project once
* Create a `addProjects` method to add a list of projects once
* Create a `setProject` method to replace the `projects` property