### PR TITLE
feat: add getResultsTotal for batchsearch and WebQueryPagination class

### DIFF
--- a/src/main/java/org/icij/datashare/batch/BatchSearchRepository.java
+++ b/src/main/java/org/icij/datashare/batch/BatchSearchRepository.java
@@ -28,6 +28,7 @@ public interface BatchSearchRepository extends Closeable {
     List<String> getQueued();
     List<SearchResult> getResults(User user, String batchSearchId);
     List<SearchResult> getResults(User user, String batchId, WebQuery webQuery);
+    int getResultsTotal(User user, String batchId, WebQuery webQuery);
 
     boolean publish(User user, String batchId, boolean published);
 
@@ -41,14 +42,10 @@ public interface BatchSearchRepository extends Closeable {
 
     boolean reset(String batchId);
     @JsonIgnoreProperties(ignoreUnknown = true)
-    class WebQuery {
+    class WebQuery extends WebQueryPagination{
         public static final String DEFAULT_SORT_FIELD = "doc_nb";
-        public final String sort;
-        public final String order;
         public final String query;
         public final String field;
-        public final int from;
-        public final int size;
         public final List<String> queries;
         public final boolean queriesExcluded;
         public final List<String> contentTypes;
@@ -67,12 +64,9 @@ public interface BatchSearchRepository extends Closeable {
                         @JsonProperty("batchDate") List<String> batchDate, @JsonProperty("state") List<String> state,
                         @JsonProperty("publishState") String publishState, @JsonProperty("withQueries") boolean withQueries,
                         @JsonProperty("queriesExcluded") boolean queriesExcluded, @JsonProperty("contentTypes") List<String> contentTypes) {
-            this.size = size;
-            this.from = from;
-            this.sort = sort == null ? DEFAULT_SORT_FIELD : sort;
+            super(sort == null ? DEFAULT_SORT_FIELD : sort, sort == null ? "asc": order,from,size);
             this.query = query;
             this.field = field;
-            this.order = sort == null ? "asc": order;
             this.queries = queries == null ? null: unmodifiableList(queries);
             this.queriesExcluded = queriesExcluded;
             this.contentTypes = contentTypes == null ? null: unmodifiableList(contentTypes);

--- a/src/main/java/org/icij/datashare/batch/WebQueryPagination.java
+++ b/src/main/java/org/icij/datashare/batch/WebQueryPagination.java
@@ -1,0 +1,16 @@
+package org.icij.datashare.batch;
+
+
+public class WebQueryPagination {
+    public final String sort;
+    public final String order;
+    public final int from;
+    public final int size;
+
+    public WebQueryPagination(String sort, String order, int from, int size) {
+        this.sort = sort;
+        this.order = order;
+        this.from = from;
+        this.size = size;
+    }
+}


### PR DESCRIPTION
Add getResultsTotal function to retrieve total of rows for filtered batch search results (without pagination window)

Done in pair prog with @bamthomas 