### PR TITLE
feature: add metadata to `NamedEntity`

### DIFF
--- a/src/main/java/org/icij/datashare/text/NamedEntitiesBuilder.java
+++ b/src/main/java/org/icij/datashare/text/NamedEntitiesBuilder.java
@@ -14,18 +14,26 @@ public class NamedEntitiesBuilder {
     private final String docId;
     private final Language language;
     private final Map<Pair<String, NamedEntity.Category>, List<Long>> mentionIndicesMap = new LinkedHashMap<>();
+    private Map<String, Object> metadata;
+
     private String rootId;
 
-    public NamedEntitiesBuilder(Pipeline.Type type, String docId, Language language) {
+
+    public NamedEntitiesBuilder(Pipeline.Type type, String docId, Language language, Map<String, Object> metadata) {
         this.type = type;
         this.docId = docId;
         this.language = language;
         this.rootId = docId;
+        this.metadata = metadata;
+    }
+
+    public NamedEntitiesBuilder(Pipeline.Type type, String docId, Language language) {
+        this(type, docId, language, null);
     }
 
     public List<NamedEntity> build() {
         return mentionIndicesMap.entrySet().stream().map(e ->
-                NamedEntity.create(e.getKey()._2(), e.getKey()._1(), e.getValue(), docId, rootId, type, language)).
+                NamedEntity.create(e.getKey()._2(), e.getKey()._1(), e.getValue(), docId, rootId, type, language, metadata)).
                 collect(Collectors.toList());
     }
 
@@ -37,6 +45,10 @@ public class NamedEntitiesBuilder {
 
     public NamedEntitiesBuilder withRoot(String rootId) {
         this.rootId = rootId;
+        return this;
+    }
+    public NamedEntitiesBuilder withMetadata(Map<String, Object> metadata) {
+        this.metadata = metadata;
         return this;
     }
 }

--- a/src/main/java/org/icij/datashare/text/NamedEntity.java
+++ b/src/main/java/org/icij/datashare/text/NamedEntity.java
@@ -47,6 +47,10 @@ public final class NamedEntity implements Entity {
     private final Pipeline.Type extractor;
     private final Language extractorLanguage;
     private final String partsOfSpeech;
+
+    // TODO: we could generics here, but that would break the API
+    private final Map<String, Object> metadata;
+
     private Boolean hidden;
 
     public enum Category implements Serializable {
@@ -101,7 +105,19 @@ public final class NamedEntity implements Entity {
                                      String rootDocument,
                                      Pipeline.Type extr,
                                      Language extrLang) {
-        return new NamedEntity(cat, mention, offsets, doc, rootDocument, extr, extrLang, false, null);
+        return new NamedEntity(cat, mention, offsets, doc, rootDocument, extr, extrLang, false, null, null);
+    }
+
+    public static NamedEntity create(Category cat,
+                                     String mention,
+                                     List<Long> offsets,
+                                     String doc,
+                                     String rootDocument,
+                                     Pipeline.Type extr,
+                                     Language extrLang,
+                                     Map<String, Object> metadata
+                                     ) {
+        return new NamedEntity(cat, mention, offsets, doc, rootDocument, extr, extrLang, false, null, metadata);
     }
 
     public static List<NamedEntity> allFrom(String text, Annotations annotations) {
@@ -133,7 +149,9 @@ public final class NamedEntity implements Entity {
                         @JsonProperty("extractor") Pipeline.Type extractor,
                         @JsonProperty("extractorLanguage") Language extractorLanguage,
                         @JsonProperty("isHidden") Boolean hidden,
-                        @JsonProperty("partOfSpeech") String partsOfSpeech) {
+                        @JsonProperty("partOfSpeech") String partsOfSpeech,
+                        @JsonProperty("metadata") Map<String, Object> metadata
+    ) {
         if (mention == null || mention.isEmpty()) {
             throw new IllegalArgumentException("Mention is undefined");
         }
@@ -153,6 +171,7 @@ public final class NamedEntity implements Entity {
         this.extractorLanguage = extractorLanguage;
         this.hidden = hidden;
         this.partsOfSpeech = partsOfSpeech;
+        this.metadata = metadata;
     }
 
     @Override
@@ -168,6 +187,7 @@ public final class NamedEntity implements Entity {
     public List<Long> getOffsets() { return offsets; }
     public Pipeline.Type getExtractor() { return extractor; }
     public Language getExtractorLanguage() { return extractorLanguage; }
+    public Map<String, Object> getMetadata() { return metadata; }
     @JsonGetter("isHidden")
     public Boolean isHidden() { return hidden; }
     public NamedEntity hide() { this.hidden = true; return this;}

--- a/src/test/java/org/icij/datashare/text/NamedEntityTest.java
+++ b/src/test/java/org/icij/datashare/text/NamedEntityTest.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.text;
 
+import java.util.Map;
 import org.icij.datashare.json.JsonObjectMapper;
 import org.icij.datashare.text.nlp.Pipeline;
 import org.junit.Test;
@@ -14,7 +15,8 @@ public class NamedEntityTest {
                 NamedEntity.Category.PERSON, "mention", asList(123L), "docId", "rootId",
                 Pipeline.Type.CORENLP, Language.ENGLISH))).
                 isEqualTo("{\"category\":\"PERSON\",\"mention\":\"mention\",\"offsets\":[123]," +
-                        "\"extractor\":\"CORENLP\",\"extractorLanguage\":\"ENGLISH\",\"isHidden\":false,\"mentionNorm\":\"mention\"," +
+                        "\"extractor\":\"CORENLP\",\"extractorLanguage\":\"ENGLISH\",\"isHidden\":false," +
+                    "\"metadata\":null,\"mentionNorm\":\"mention\"," +
                         "\"partsOfSpeech\":null,\"mentionNormTextLength\":7}");
     }
 
@@ -25,5 +27,17 @@ public class NamedEntityTest {
                 Pipeline.Type.CORENLP, Language.JAPANESE)))
                     .contains("\"mentionNormTextLength\":3")
                     .contains("\"mentionNorm\":\"mao\"");
+    }
+
+    @Test
+    public void test_serialize_with_metadata() throws Exception {
+        Map<String, Object> meta = Map.of("some", "metadata");
+        assertThat(JsonObjectMapper.MAPPER.writeValueAsString(NamedEntity.create(
+                NamedEntity.Category.PERSON, "mention", asList(123L), "docId", "rootId",
+                Pipeline.Type.CORENLP, Language.ENGLISH, meta))).
+                isEqualTo("{\"category\":\"PERSON\",\"mention\":\"mention\",\"offsets\":[123]," +
+                        "\"extractor\":\"CORENLP\",\"extractorLanguage\":\"ENGLISH\",\"isHidden\":false," +
+                    "\"metadata\":{\"some\":\"metadata\"},\"mentionNorm\":\"mention\"," +
+                        "\"partsOfSpeech\":null,\"mentionNormTextLength\":7}");
     }
 }

--- a/src/test/java/org/icij/datashare/text/nlp/NamedEntitiesBuilderTest.java
+++ b/src/test/java/org/icij/datashare/text/nlp/NamedEntitiesBuilderTest.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.text.nlp;
 
+import java.util.Map;
 import org.icij.datashare.text.Language;
 import org.icij.datashare.text.NamedEntitiesBuilder;
 import org.icij.datashare.text.NamedEntity;
@@ -53,5 +54,13 @@ public class NamedEntitiesBuilderTest {
         NamedEntity namedEntity = new NamedEntitiesBuilder(CORENLP, "docId", Language.ENGLISH).
                 add(PERSON, "mention1", 12L).withRoot("rootId").build().get(0);
         assertThat(namedEntity.getRootDocument()).isEqualTo("rootId");
+    }
+
+    @Test
+    public void test_ne_with_metadata() {
+        Map<String, Object> meta = Map.of("some", "metadata");
+        NamedEntity namedEntity = new NamedEntitiesBuilder(CORENLP, "docId", Language.ENGLISH).
+                add(PERSON, "mention1", 12L).withMetadata(meta).build().get(0);
+        assertThat(namedEntity.getMetadata()).isEqualTo(meta);
     }
 }


### PR DESCRIPTION
# TODO
- [ ] double check retro compatibility build building datashare with it

# PR description

This PR adds arbitraty metadata to `NamedEntity`.

In order to be retro compatible (and avoid updating all `NamedEntity` pipelines) this PR adds them as optional and as a `private final Map<String, Object> metadata;`. A better but breaking implementation would probably have been to use generics: `NamedEntity<M>` and `private final M metadata;`. This if left for later.

# Changes
## Added 
- added an arbitrary `private final Map<String, Object> metadata;` to the `NamedEntity`

## Changed
- updated `NamedEntityBuilder` to support metadata