### PR TITLE
fix: `NamedEntity.id` generation

### DIFF
--- a/src/main/java/org/icij/datashare/text/NamedEntity.java
+++ b/src/main/java/org/icij/datashare/text/NamedEntity.java
@@ -158,7 +158,6 @@ public final class NamedEntity implements Entity {
         }
         this.mentionNorm = normalize(mention);
         ArrayList<String> hashed = Stream.of(
-            "|",
             documentId,
             String.valueOf(offsets),
             extractor.toString(),

--- a/src/main/java/org/icij/datashare/text/NamedEntity.java
+++ b/src/main/java/org/icij/datashare/text/NamedEntity.java
@@ -1,6 +1,7 @@
 package org.icij.datashare.text;
 
 import com.fasterxml.jackson.annotation.*;
+import java.util.stream.Stream;
 import me.xuender.unidecode.Unidecode;
 import org.icij.datashare.Entity;
 import org.icij.datashare.function.ThrowingFunction;
@@ -156,12 +157,22 @@ public final class NamedEntity implements Entity {
             throw new IllegalArgumentException("Mention is undefined");
         }
         this.mentionNorm = normalize(mention);
-        this.id = HASHER.hash( String.join("|",
-                documentId,
-                String.valueOf(offsets),
-                extractor.toString(),
-                mentionNorm
-        ));
+        ArrayList<String> hashed = Stream.of(
+            "|",
+            documentId,
+            String.valueOf(offsets),
+            extractor.toString(),
+            mentionNorm
+        ).collect(Collectors.toCollection(ArrayList::new));
+        this.metadata = metadata;
+        if (this.metadata != null) {
+            hashed.addAll(this.metadata.entrySet()
+                .stream()
+                .sorted(Map.Entry.comparingByKey())
+                .flatMap(e -> Stream.of(e.getKey(), String.valueOf(e.getValue().hashCode())))
+                .collect(Collectors.toList()));
+        }
+        this.id = HASHER.hash(String.join("|", hashed));
         this.category = Optional.ofNullable(category).orElse(UNKNOWN);
         this.mention = mention;
         this.documentId = documentId;
@@ -171,7 +182,7 @@ public final class NamedEntity implements Entity {
         this.extractorLanguage = extractorLanguage;
         this.hidden = hidden;
         this.partsOfSpeech = partsOfSpeech;
-        this.metadata = metadata;
+
     }
 
     @Override

--- a/src/test/java/org/icij/datashare/text/NamedEntityTest.java
+++ b/src/test/java/org/icij/datashare/text/NamedEntityTest.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.text;
 
+import java.util.List;
 import java.util.Map;
 import org.icij.datashare.json.JsonObjectMapper;
 import org.icij.datashare.text.nlp.Pipeline;
@@ -39,5 +40,25 @@ public class NamedEntityTest {
                         "\"extractor\":\"CORENLP\",\"extractorLanguage\":\"ENGLISH\",\"isHidden\":false," +
                     "\"metadata\":{\"some\":\"metadata\"},\"mentionNorm\":\"mention\"," +
                         "\"partsOfSpeech\":null,\"mentionNormTextLength\":7}");
+    }
+
+    @Test
+    public void test_id_with_metadata() {
+        // Given
+        Map<String, Object> meta = Map.of("some", "meta", "da", "ta");
+        Map<String, Object> sameMetaDifferentOrder = Map.of("da", "ta", "some", "meta");
+        Map<String, Object> otherMeta = Map.of("some", "othermetadata");
+
+        // When
+        NamedEntity withMeta = NamedEntity.create(NamedEntity.Category.PERSON, "mention", List.of(123L), "docId", "rootId",
+                Pipeline.Type.CORENLP, Language.ENGLISH, meta);
+        NamedEntity withSameMeta = NamedEntity.create(NamedEntity.Category.PERSON, "mention", List.of(123L), "docId", "rootId",
+                Pipeline.Type.CORENLP, Language.ENGLISH, sameMetaDifferentOrder);
+        NamedEntity withOtherMeta = NamedEntity.create(NamedEntity.Category.PERSON, "mention", List.of(123L), "docId", "rootId",
+                Pipeline.Type.CORENLP, Language.ENGLISH, otherMeta);
+
+        // Then
+        assertThat(withMeta.getId()).isEqualTo(withSameMeta.getId());
+        assertThat(withMeta.getId()).isNotEqualTo(withOtherMeta.getId());
     }
 }

--- a/src/test/java/org/icij/datashare/text/NamedEntityTest.java
+++ b/src/test/java/org/icij/datashare/text/NamedEntityTest.java
@@ -61,4 +61,21 @@ public class NamedEntityTest {
         assertThat(withMeta.getId()).isEqualTo(withSameMeta.getId());
         assertThat(withMeta.getId()).isNotEqualTo(withOtherMeta.getId());
     }
+
+    @Test
+    public void test_id_with_metadata_should_be_backward_compatible() {
+        // Given
+        final NamedEntity ent = NamedEntity.create(
+                NamedEntity.Category.PERSON,
+            "mention",
+            List.of(123L),
+            "docId",
+            "rootId",
+            Pipeline.Type.CORENLP,
+            Language.ENGLISH
+        );
+        // Then
+        String idBeforeMetadataAddition = "00a4edf271b22560567021466076e23ce1a1cf9000225692c5a88545491115c28b49fdd56ae30af9ae3065ec9f06541f";
+        assertThat(ent.getId()).isEqualTo(idBeforeMetadataAddition);
+    }
 }


### PR DESCRIPTION
# TODO
- [x] add a backward compatibility test to make sure IDs are the same as in `11.2.0`

# Changes
## Fixed
- account for `NamedEntity.metadata` when generating the `NamedEntity.id`