### PR TITLE
fix: `DocumentBuilder.build()` swapping `rootId` and `parentId`

### DIFF
--- a/src/main/java/org/icij/datashare/text/DocumentBuilder.java
+++ b/src/main/java/org/icij/datashare/text/DocumentBuilder.java
@@ -140,7 +140,7 @@ public class DocumentBuilder {
         }
         return new Document(project, id, path, content, content_translated, language,
                 charset, mimeType, metadata, documentStatus,
-                pipelines, extractionDate, rootId, parentId, extractionLevel,
+                pipelines, extractionDate, parentId, rootId, extractionLevel,
                 contentLength, tags);
     }
 

--- a/src/test/java/org/icij/datashare/text/DocumentBuilderTest.java
+++ b/src/test/java/org/icij/datashare/text/DocumentBuilderTest.java
@@ -1,0 +1,65 @@
+package org.icij.datashare.text;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.text.nlp.Pipeline.Type.CORENLP;
+
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+
+public class DocumentBuilderTest {
+    @Test
+    public void test_build() {
+        // Given
+        String docId = "someId";
+        String rootId = "rootId";
+        String parentId = "parentId";
+        short extractionLevel = (short) 1;
+        long contentLength = 11L;
+        Project project = Project.project("someProject");
+        Tag sometag = Tag.tag("sometag");
+        Document.Status status = Document.Status.INDEXED;
+        Date extractionDate = Date.from(Instant.now());
+        String mimeType = "SOME/MIME";
+        List<Map<String, String>> contentTranslated = List.of(Map.of("french", "ducontenu"));
+        Map<String, Object> metadata = Map.of("some", "metadata");
+        DocumentBuilder builder = DocumentBuilder.createDoc()
+            .withDefaultValues(docId)
+            .withRootId(rootId)
+            .withParentId(parentId)
+            .withExtractionLevel(extractionLevel)
+            .withContentLength(contentLength)
+            .with(project)
+            .with(sometag)
+            .with(status)
+            .with(CORENLP)
+            .extractedAt(extractionDate)
+            .with(Charset.defaultCharset())
+            .ofMimeType(mimeType)
+            .with(contentTranslated)
+            .with(metadata)
+            .with(Language.ENGLISH)
+            .with(Path.of("some/path"))
+            .with("somecontent");
+        // When
+        Document doc = builder.build();
+        // Then
+        assertThat(doc.getId()).isEqualTo(docId);
+        assertThat(doc.getRootDocument()).isEqualTo(rootId);
+        assertThat(doc.getParentDocument()).isEqualTo(parentId);
+        assertThat(doc.getExtractionLevel()).isEqualTo(extractionLevel);
+        assertThat(doc.getContentLength()).isEqualTo(contentLength);
+        assertThat(doc.getProject()).isEqualTo(project);
+        assertThat(doc.getTags()).isEqualTo(Set.of(sometag));
+        assertThat(doc.getStatus()).isEqualTo(status);
+        assertThat(doc.getExtractionDate()).isEqualTo(extractionDate);
+        assertThat(doc.getContentTranslated()).isEqualTo(contentTranslated);
+        assertThat(doc.getMetadata()).isEqualTo(metadata);
+    }
+}


### PR DESCRIPTION
# Changes
## Fixed
- [added an arbitrary `private final Map<String, Object> metadata;` to the `NamedEntity`](fix: DocumentBuilder.build() swapping rootId and parentId) in document creation
