### PR TITLE
feat: serializable document user recommendation

### DIFF
--- a/src/main/java/org/icij/datashare/DocumentUserRecommendation.java
+++ b/src/main/java/org/icij/datashare/DocumentUserRecommendation.java
@@ -4,18 +4,45 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Project;
+import org.icij.datashare.time.DatashareTime;
 import org.icij.datashare.user.User;
+
+import java.util.Date;
+import java.util.Objects;
 
 public class DocumentUserRecommendation {
 
     public final Project project;
     public final Document document;
     public final User user;
+    public final Date creationDate;
 
     @JsonCreator
-    public DocumentUserRecommendation(@JsonProperty("document") Document document, @JsonProperty("project") Project project, @JsonProperty("user") User user) {
+    public DocumentUserRecommendation(@JsonProperty("document") Document document, @JsonProperty("project") Project project, @JsonProperty("user") User user, @JsonProperty("creationDate") Date creationDate) {
         this.document = document;
         this.project = project;
         this.user = user;
+        this.creationDate = creationDate;
+    }
+    public DocumentUserRecommendation(@JsonProperty("document") Document document, @JsonProperty("project") Project project, @JsonProperty("user") User user) {
+        this(document, project, user, DatashareTime.getInstance().now());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DocumentUserRecommendation that = (DocumentUserRecommendation) o;
+        return Objects.equals(project, that.project) && Objects.equals(document, that.document) && Objects.equals(user, that.user);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(project, document, user);
+    }
+
+    @Override
+    public String toString() {
+        return "DocumentUserRecommendation{project=" + project + ", document=" + document + ", user=" + user + '}';
     }
 }

--- a/src/main/java/org/icij/datashare/DocumentUserRecommendation.java
+++ b/src/main/java/org/icij/datashare/DocumentUserRecommendation.java
@@ -1,0 +1,21 @@
+package org.icij.datashare;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.icij.datashare.text.Document;
+import org.icij.datashare.text.Project;
+import org.icij.datashare.user.User;
+
+public class DocumentUserRecommendation {
+
+    public final Project project;
+    public final Document document;
+    public final User user;
+
+    @JsonCreator
+    public DocumentUserRecommendation(@JsonProperty("document") Document document, @JsonProperty("project") Project project, @JsonProperty("user") User user) {
+        this.document = document;
+        this.project = project;
+        this.user = user;
+    }
+}

--- a/src/main/java/org/icij/datashare/Repository.java
+++ b/src/main/java/org/icij/datashare/Repository.java
@@ -33,6 +33,7 @@ public interface Repository {
 
     // document user recommendations
     List<DocumentUserRecommendation> getDocumentUserRecommendations(int from, int size);
+    List<DocumentUserRecommendation> getDocumentUserRecommendations(int from, int size, List<Project> projects);
     int recommend(Project project, User user, List<String> documentIds);
     int unrecommend(Project project, User user, List<String> documentIds);
 

--- a/src/main/java/org/icij/datashare/Repository.java
+++ b/src/main/java/org/icij/datashare/Repository.java
@@ -31,11 +31,14 @@ public interface Repository {
     List<String> getStarredDocuments(Project project, User user);
     Set<String> getRecommentationsBy(Project project, List<User> users);
 
+    // document user recommendations
+    List<DocumentUserRecommendation> getDocumentUserRecommendations(int from, int size);
+    int recommend(Project project, User user, List<String> documentIds);
+    int unrecommend(Project project, User user, List<String> documentIds);
+
     // standalone (to remove later ?)
     int star(Project project, User user, List<String> documentIds);
     int unstar(Project project, User user, List<String> documentIds);
-    int recommend(Project project, User user, List<String> documentIds);
-    int unrecommend(Project project, User user, List<String> documentIds);
     boolean tag(Project prj, String documentId, Tag... tags);
     boolean untag(Project prj, String documentId, Tag... tags);
     boolean tag(Project prj, List<String> documentIds, Tag... tags);

--- a/src/test/java/org/icij/datashare/DocumentUserRecommendationTest.java
+++ b/src/test/java/org/icij/datashare/DocumentUserRecommendationTest.java
@@ -1,0 +1,40 @@
+package org.icij.datashare;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.icij.datashare.json.JsonObjectMapper;
+import org.icij.datashare.text.Document;
+import org.icij.datashare.text.DocumentBuilder;
+import org.icij.datashare.text.Project;
+import org.icij.datashare.user.User;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+
+public class DocumentUserRecommendationTest {
+    @Test
+    public void serialize_document_user_recommendation() throws JsonProcessingException {
+        Project project = Project.project("uber-files");
+        Document document = DocumentBuilder.createDoc("foo").with(project).with(Paths.get("/tmp/file.txt")).build();
+        User user = new User("bar", "Jane Doe", "jdoe@icij.org");
+
+        DocumentUserRecommendation recommendation = new DocumentUserRecommendation(document, project, user);
+
+        assertThat(JsonObjectMapper.MAPPER.writeValueAsString(recommendation))
+                .contains("\"name\":\"uber-files\"")
+                .contains("\"id\":\"foo\"")
+                .contains("\"id\":\"bar\"");
+    }
+
+    @Test
+    public void deserialize_document_user_recommendation() throws IOException {
+        String json = "{\"project\":{\"name\":\"uber-files\"},\"user\":{\"id\":\"bar\",\"name\":\"Jane Doe\",\"details\":{}},\"document\":{\"id\":\"foo\"}}";
+        DocumentUserRecommendation recomendation = JsonObjectMapper.MAPPER.readValue(json, DocumentUserRecommendation.class);
+        assertThat(recomendation.project.getId()).isEqualTo("uber-files");
+        assertThat(recomendation.document.getId()).isEqualTo("foo");
+        assertThat(recomendation.user.getId()).isEqualTo("bar");
+    }
+}


### PR DESCRIPTION
This PR adds a `DocumentUserRecommendation` class which can be used to list all document recommendation by users. It's a part of https://github.com/ICIJ/datashare/issues/1229).