### PR TITLE
feat: adds tags in batch search

### DIFF
--- a/src/main/java/org/icij/datashare/batch/BatchSearch.java
+++ b/src/main/java/org/icij/datashare/batch/BatchSearch.java
@@ -1,14 +1,10 @@
 package org.icij.datashare.batch;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.JsonNode;
-import org.icij.datashare.json.JsonObjectMapper;
 import org.icij.datashare.text.ProjectProxy;
 import org.icij.datashare.time.DatashareTime;
 import org.icij.datashare.user.User;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import static java.util.Collections.unmodifiableList;

--- a/src/main/java/org/icij/datashare/text/indexing/Indexer.java
+++ b/src/main/java/org/icij/datashare/text/indexing/Indexer.java
@@ -53,6 +53,7 @@ public interface Indexer extends Closeable {
         Stream<? extends Entity> scroll() throws IOException;
         Stream<? extends Entity> scroll(int numSlice, int nbSlices) throws IOException;
         Searcher set(JsonNode jsonQuery);
+        Searcher setFromTemplate(String jsonQueryTemplate, String query);
         Searcher withSource(String... fields);
         Searcher withoutSource(String... fields);
         Searcher withSource(boolean source);

--- a/src/test/java/org/icij/datashare/batch/BatchSearchTest.java
+++ b/src/test/java/org/icij/datashare/batch/BatchSearchTest.java
@@ -4,12 +4,16 @@ import org.icij.datashare.time.DatashareTime;
 import org.icij.datashare.user.User;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.*;
+import static java.util.Collections.singletonList;
 import static org.fest.assertions.Assertions.assertThat;
-import static org.icij.datashare.text.Project.*;
+import static org.icij.datashare.CollectionUtils.asSet;
+import static org.icij.datashare.text.Project.project;
 
 public class BatchSearchTest {
     @Test(expected = IllegalArgumentException.class)
@@ -23,11 +27,24 @@ public class BatchSearchTest {
     }
 
     @Test
+    public void test_has_query_body_true() {
+        String query = "{\"query\":3}";
+        assertThat(new BatchSearch(singletonList(project("prj")), "name", "desc",
+                asSet("q1", "q2"), User.local(), true, singletonList("application/json"), "{\"query\":3}",
+                asList("/path/to/docs", "/path/to/pdfs"), 3,true).hasQueryBody()).isTrue();
+    }
+    public void test_query_as_json_should_throw_exception_when_query_body_is_null() {
+        assertThat(new BatchSearch(singletonList(project("prj")), "name", "desc",
+                asSet("q1", "q2"), User.local(), true, singletonList("application/json"), null,
+                asList("/path/to/docs", "/path/to/pdfs"), 3,true).hasQueryBody()).isFalse();
+    }
+
+    @Test
     public void test_copy_constructor() {
         DatashareTime.setMockTime(true);
         BatchSearch batchSearch = new BatchSearch("uuid", singletonList(project("prj")), "name", "desc", new LinkedHashMap<String, Integer>() {{ put("query", 3);}},
                 new Date(), BatchSearchRecord.State.FAILURE, User.local(), 123, true,
-                singletonList("application/pdf"), singletonList("tag"),singletonList("path"), 2, true,
+                singletonList("application/pdf"), "{\"test\": 42}",singletonList("path"), 2, true,
                 "error message", "error query");
 
         BatchSearch copy = new BatchSearch(batchSearch);
@@ -44,7 +61,7 @@ public class BatchSearchTest {
         assertThat(copy.name).isEqualTo(batchSearch.name);
         assertThat(copy.description).isEqualTo(batchSearch.description);
         assertThat(copy.fileTypes).isEqualTo(batchSearch.fileTypes);
-        assertThat(copy.tags).isEqualTo(batchSearch.tags);
+        assertThat(copy.queryBody).isEqualTo(batchSearch.queryBody);
         assertThat(copy.fuzziness).isEqualTo(batchSearch.fuzziness);
         assertThat(copy.paths).isEqualTo(batchSearch.paths);
         assertThat(copy.published).isEqualTo(batchSearch.published);
@@ -56,7 +73,7 @@ public class BatchSearchTest {
         DatashareTime.setMockTime(true);
         BatchSearch batchSearch = new BatchSearch("uuid", asList(project("prj1"), project("prj2")), "name", "desc", new LinkedHashMap<String, Integer>() {{ put("query", 3);}},
                 new Date(), BatchSearchRecord.State.FAILURE, User.local(), 123, true,
-                singletonList("application/pdf"), singletonList("tag"),singletonList("path"), 2, true,
+                singletonList("application/pdf"), null,singletonList("path"), 2, true,
                 "error message", "error query");
 
         BatchSearch copy = new BatchSearch(batchSearch, new HashMap<String, String>() {{

--- a/src/test/java/org/icij/datashare/batch/BatchSearchTest.java
+++ b/src/test/java/org/icij/datashare/batch/BatchSearchTest.java
@@ -33,7 +33,8 @@ public class BatchSearchTest {
                 asSet("q1", "q2"), User.local(), true, singletonList("application/json"), "{\"query\":3}",
                 asList("/path/to/docs", "/path/to/pdfs"), 3,true).hasQueryBody()).isTrue();
     }
-    public void test_query_as_json_should_throw_exception_when_query_body_is_null() {
+    @Test
+    public void test_has_query_body_false() {
         assertThat(new BatchSearch(singletonList(project("prj")), "name", "desc",
                 asSet("q1", "q2"), User.local(), true, singletonList("application/json"), null,
                 asList("/path/to/docs", "/path/to/pdfs"), 3,true).hasQueryBody()).isFalse();


### PR DESCRIPTION
PR related to [this issue](https://github.com/ICIJ/datashare/issues/1071) and [this one](https://github.com/ICIJ/datashare/issues/1248).

The PR adds replace the `tag` attribute by a `queryBody` attribute in the `BatchSearch` model. It also adds a method in the `Indexer` interface