### PR TITLE
feat: add queue hash methods to properties provider

### DIFF
--- a/src/main/java/org/icij/datashare/PropertiesProvider.java
+++ b/src/main/java/org/icij/datashare/PropertiesProvider.java
@@ -11,9 +11,12 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.lang.Character.toUpperCase;
 import static java.lang.System.getenv;
@@ -31,6 +34,9 @@ public class PropertiesProvider {
     public static final String QUEUE_NAME_OPTION = "queueName";
     public static final String SET_NAME_OPTION = "filterSet";
     public static final String MAP_NAME_OPTION = "reportName";
+    public static final String DATA_DIR_OPTION = "dataDir";
+    public static final String DEFAULT_PROJECT_OPTION = "defaultProject";
+    public static final List<String> QUEUE_HASH_PROPERTIES = List.of(QUEUE_NAME_OPTION, DATA_DIR_OPTION);
 
 
     private Logger logger = LoggerFactory.getLogger(getClass());
@@ -146,6 +152,20 @@ public class PropertiesProvider {
 
     public Object setProperty(String key, String value) {
         return getProperties().setProperty(key, value);
+    }
+
+    public List<String> queueHashProperties() {
+        return QUEUE_HASH_PROPERTIES.stream()
+                .map(p -> get(p).orElse("-"))
+                .map(String::hashCode)
+                .map(String::valueOf)
+                .collect(Collectors.toList());
+    }
+
+    public String queueHash() {
+        String defaultProject = get(DEFAULT_PROJECT_OPTION).orElse("-");
+        return Stream.concat(Stream.of(defaultProject), queueHashProperties().stream())
+                .collect(Collectors.joining(":"));
     }
 
     private void putAllIfIsAbsent(Properties dest, Properties propertiesToMerge) {

--- a/src/main/java/org/icij/datashare/PropertiesProvider.java
+++ b/src/main/java/org/icij/datashare/PropertiesProvider.java
@@ -36,7 +36,8 @@ public class PropertiesProvider {
     public static final String MAP_NAME_OPTION = "reportName";
     public static final String DATA_DIR_OPTION = "dataDir";
     public static final String DEFAULT_PROJECT_OPTION = "defaultProject";
-    public static final List<String> QUEUE_HASH_PROPERTIES = List.of(QUEUE_NAME_OPTION, DATA_DIR_OPTION);
+    public static final List<String> QUEUE_HASH_PROPERTIES = List.of(DATA_DIR_OPTION);
+    public static final String QUEUE_SEPARATOR = ":";
 
 
     private Logger logger = LoggerFactory.getLogger(getClass());
@@ -115,6 +116,17 @@ public class PropertiesProvider {
         return this.overrideWith(propertiesProvider.getProperties());
     }
 
+    public PropertiesProvider overrideQueueNameWithHash() {
+        Map<String, String> map = Map.of(QUEUE_NAME_OPTION, queueNameWithHash());
+        return new PropertiesProvider(createOverriddenWith(map));
+    }
+
+    public PropertiesProvider overrideQueueNameWithHash(String defaultProject) {
+        Properties properties = createOverriddenWith(Map.of(DEFAULT_PROJECT_OPTION, defaultProject));
+        PropertiesProvider propertiesProvider = new PropertiesProvider(properties);
+        return propertiesProvider.overrideQueueNameWithHash();
+    }
+
     public Properties createOverriddenWith(Map<String, String> map) {
         Properties overriddenProperties = (Properties) getProperties().clone();
         overriddenProperties.putAll(map);
@@ -165,8 +177,17 @@ public class PropertiesProvider {
     public String queueHash() {
         String defaultProject = get(DEFAULT_PROJECT_OPTION).orElse("-");
         return Stream.concat(Stream.of(defaultProject), queueHashProperties().stream())
-                .collect(Collectors.joining(":"));
+                .collect(Collectors.joining(QUEUE_SEPARATOR));
     }
+
+    public String queueNameWithHash() {
+        return queueName() + QUEUE_SEPARATOR + queueHash();
+    }
+
+    public String queueName() {
+        return get(QUEUE_NAME_OPTION).orElse("extract:queue");
+    }
+
 
     private void putAllIfIsAbsent(Properties dest, Properties propertiesToMerge) {
         for (Map.Entry entry: propertiesToMerge.entrySet()) {

--- a/src/main/java/org/icij/datashare/PropertiesProvider.java
+++ b/src/main/java/org/icij/datashare/PropertiesProvider.java
@@ -144,14 +144,14 @@ public class PropertiesProvider {
         return properties;
     }
 
+    public Object setProperty(String key, String value) {
+        return getProperties().setProperty(key, value);
+    }
+
     private void putAllIfIsAbsent(Properties dest, Properties propertiesToMerge) {
         for (Map.Entry entry: propertiesToMerge.entrySet()) {
             dest.putIfAbsent(entry.getKey(), entry.getValue());
         }
-    }
-
-    public Object setProperty(String key, String value) {
-        return getProperties().setProperty(key, value);
     }
 
     private Path getFilePath(String fileName) {

--- a/src/main/java/org/icij/datashare/PropertiesProvider.java
+++ b/src/main/java/org/icij/datashare/PropertiesProvider.java
@@ -105,6 +105,10 @@ public class PropertiesProvider {
         return this;
     }
 
+    public PropertiesProvider overrideWith(final PropertiesProvider propertiesProvider) {
+        return this.overrideWith(propertiesProvider.getProperties());
+    }
+
     public Properties createOverriddenWith(Map<String, String> map) {
         Properties overriddenProperties = (Properties) getProperties().clone();
         overriddenProperties.putAll(map);
@@ -144,6 +148,10 @@ public class PropertiesProvider {
         for (Map.Entry entry: propertiesToMerge.entrySet()) {
             dest.putIfAbsent(entry.getKey(), entry.getValue());
         }
+    }
+
+    public Object setProperty(String key, String value) {
+        return getProperties().setProperty(key, value);
     }
 
     private Path getFilePath(String fileName) {

--- a/src/test/java/org/icij/datashare/PropertiesProviderTest.java
+++ b/src/test/java/org/icij/datashare/PropertiesProviderTest.java
@@ -72,6 +72,16 @@ public class PropertiesProviderTest {
     }
 
     @Test
+    public void test_override_properties_in_properties_provider() {
+        PropertiesProvider propertiesProvider = new PropertiesProvider();
+        propertiesProvider.setProperty("foo", "baz");
+        propertiesProvider.setProperty("bar", "qux");
+
+        Properties merged = new PropertiesProvider().overrideWith(propertiesProvider).getProperties();
+        assertThat(merged).includes(entry("foo", "baz"), entry("messageBusAddress", "redis"), entry("bar", "qux"));
+    }
+
+    @Test
     public void test_create_overridden_with() {
         Properties properties = new Properties();
         properties.setProperty("foo", "baz");

--- a/src/test/java/org/icij/datashare/PropertiesProviderTest.java
+++ b/src/test/java/org/icij/datashare/PropertiesProviderTest.java
@@ -200,15 +200,6 @@ public class PropertiesProviderTest {
         assertThat(new PropertiesProvider(settings.getAbsolutePath()).isFileReadable(settings.toPath())).isTrue();
         assertThat(settings).exists();
     }
-
-    @Test
-    public void test_unique_hash_code_by_queue_name() {
-        PropertiesProvider foo = new PropertiesProvider(Map.of("queueName", "foo"));
-        PropertiesProvider bar = new PropertiesProvider(Map.of("queueName", "bar"));
-
-        assertThat(foo.queueHash()).isNotEqualTo(bar.queueHash());
-    }
-
     @Test
     public void test_unique_hash_code_by_data_dir() {
         PropertiesProvider foo = new PropertiesProvider(Map.of("dataDir", "/foo"));
@@ -224,6 +215,29 @@ public class PropertiesProviderTest {
 
         assertThat(foo.queueHash()).startsWith("foo:");
         assertThat(bar.queueHash()).startsWith("bar:");
+    }
+
+    @Test
+    public void test_unique_queue_name_with_hash_code_starting_with_default_project() {
+        PropertiesProvider foo = new PropertiesProvider(Map.of("defaultProject", "foo"));
+        PropertiesProvider bar = new PropertiesProvider(Map.of("defaultProject", "bar"));
+
+        assertThat(foo.queueNameWithHash()).startsWith("extract:queue:foo:");
+        assertThat(bar.queueNameWithHash()).startsWith("extract:queue:bar:");
+    }
+
+    @Test
+    public void test_override_queue_name_with_hash_code_starting_with_default_project() {
+        PropertiesProvider props = new PropertiesProvider(Map.of("defaultProject", "foo"));
+        assertThat(props.queueName()).isEqualTo("extract:queue");
+        assertThat(props.overrideQueueNameWithHash().queueName()).isEqualTo(props.queueNameWithHash());
+    }
+
+    @Test
+    public void test_override_queue_name_with_hash_code_starting_with_new_project() {
+        PropertiesProvider props = new PropertiesProvider();
+        assertThat(props.queueName()).isEqualTo("extract:queue");
+        assertThat(props.overrideQueueNameWithHash("bar").queueName()).startsWith("extract:queue:bar:");
     }
 
 

--- a/src/test/java/org/icij/datashare/PropertiesProviderTest.java
+++ b/src/test/java/org/icij/datashare/PropertiesProviderTest.java
@@ -201,6 +201,32 @@ public class PropertiesProviderTest {
         assertThat(settings).exists();
     }
 
+    @Test
+    public void test_unique_hash_code_by_queue_name() {
+        PropertiesProvider foo = new PropertiesProvider(Map.of("queueName", "foo"));
+        PropertiesProvider bar = new PropertiesProvider(Map.of("queueName", "bar"));
+
+        assertThat(foo.queueHash()).isNotEqualTo(bar.queueHash());
+    }
+
+    @Test
+    public void test_unique_hash_code_by_data_dir() {
+        PropertiesProvider foo = new PropertiesProvider(Map.of("dataDir", "/foo"));
+        PropertiesProvider bar = new PropertiesProvider(Map.of("dataDir", "/bar"));
+
+        assertThat(foo.queueHash()).isNotEqualTo(bar.queueHash());
+    }
+
+    @Test
+    public void test_unique_hash_code_starting_with_default_project() {
+        PropertiesProvider foo = new PropertiesProvider(Map.of("defaultProject", "foo"));
+        PropertiesProvider bar = new PropertiesProvider(Map.of("defaultProject", "bar"));
+
+        assertThat(foo.queueHash()).startsWith("foo:");
+        assertThat(bar.queueHash()).startsWith("bar:");
+    }
+
+
     /**
      * see https://stackoverflow.com/questions/318239/how-do-i-set-environment-variables-from-java
      */


### PR DESCRIPTION
## PR Description

This PR adds several helper methods to the PropertiesProvider to simplify the creation of unique hash for the queueName (as part of https://github.com/ICIJ/datashare/issues/1337)

## Changes

* new method `PropertiesProvider.queueName()` to get the queue name
* new method `PropertiesProvider.queueNameWithHash()` to get the queue name with a hash
* new method `PropertiesProvider.overrideQueueNameWithHash()` to override the queue name with  the hash
* new method `PropertiesProvider.overrideQueueNameWithHash(defaultProject)` to override the default project and therefore the queue name with hash

## Queue Name Hash

The queue name hash is a concatenation of the following parts:

* `defaultProject`
* `dataDir` hashed with `hashCode` (numeric hash providing enough entropy)
