### PR TITLE
fix: aws s3 error while downloading NER models

### DIFF
--- a/src/main/java/org/icij/datashare/io/RemoteFiles.java
+++ b/src/main/java/org/icij/datashare/io/RemoteFiles.java
@@ -1,6 +1,8 @@
 package org.icij.datashare.io;
 
 import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
@@ -45,17 +47,8 @@ public class RemoteFiles {
         config.setConnectionTimeout(CONNECTION_TIMEOUT_MS);
         config.setSocketTimeout(READ_TIMEOUT_MS);
         return new RemoteFiles(AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
                 .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(S3_DATASHARE_ENDPOINT, S3_REGION))
-                .withClientConfiguration(config).build(), S3_DATASHARE_BUCKET_NAME);
-    }
-
-    public static RemoteFiles getAuthenticated() {
-        ClientConfiguration config = new ClientConfiguration();
-        config.setConnectionTimeout(CONNECTION_TIMEOUT_MS);
-        config.setSocketTimeout(READ_TIMEOUT_MS);
-        return new RemoteFiles(AmazonS3ClientBuilder.standard()
-                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(S3_DATASHARE_ENDPOINT, S3_REGION))
-                .withCredentials(DefaultAWSCredentialsProviderChain.getInstance())
                 .withClientConfiguration(config).build(), S3_DATASHARE_BUCKET_NAME);
     }
 


### PR DESCRIPTION
Related to [this issue](https://github.com/ICIJ/datashare/issues/598)

The problem in the referenced issue happened because of our use of the [standard aws S3 client builder](https://github.com/ICIJ/datashare-api/blob/22df41fbf41de47786991398d75453d85708f454/src/main/java/org/icij/datashare/io/RemoteFiles.java#L47).
Before each requests to S3, this standard client checks if it can find aws credentials through [four providers](https://github.com/aws/aws-sdk-java/blob/7b291bfc93ff1e8f4eb9c2af11985cc5108a2f19/aws-java-sdk-core/src/main/java/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.java#L45)
It will check access id and secret key :
1. in the variable environments
2. in the java system properties
3. in the aws profile (`~/.aws/credentials`)
4. in the aws container variable environment

If it fails to find the credentials it will make the request anonymously (the case that we want)
This is prone to errors. For example, an user that has awscli installed for an unrelated use of Datashare wouldn't be able to download the NER models if his AWS access key is expired (case 1 and 3).

This PR aims to use directly the AnonymousAWSCredentials provider in order to always download models successfuflly

Edit : `RemoteFiles getAuthenticated()` function was not used
